### PR TITLE
split topic validation to be subscription or publication driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,9 @@ pywis-topics topic validate subscription origin/a/wis2/+/data/core --no-strict
 
 ```bash
 # validate a WIS2 topic hierarchy
-pywis-topics topic validate publication origin/a/wis2/ca-eccc-msc  # fails
+pywis-topics topic validate publication origin/a/wis2/ca-eccc-msc
+pywis-topics topic validate publication origin/a/wis2/ca-eccc-msc/ocean
 pywis-topics topic validate publication origin/a/wis2/us-noaa-nws/data/core/weather/surface-based-observations/synop
-
-# validate a WIS2 topic hierarchy
-pywis-topics topic validate publication origin/a/wis2/ca-eccc-msc  # fails
 # validate a WIS2 topic hierarchy in no-strict mode
 pywis-topics topic validate publication --no-strict origin/a/wis2/fake-centre-id/data/core
 ```

--- a/README.md
+++ b/README.md
@@ -49,20 +49,33 @@ pywis-topics --version
 pywis-topics bundle sync
 ```
 
-### Listing and validation
+### Listing and validating topics for subscription
 
 ```bash
 # validate a WIS2 topic hierarchy
-pywis-topics topic validate origin/a/wis2/ca-eccc-msc
+pywis-topics topic validate subscription origin/a/wis2/ca-eccc-msc
 
 # validate a WIS2 topic hierarchy in no-strict mode
-pywis-topics topic validate --no-strict origin/a/wis2/fake-centre-id/data/core
+pywis-topics topic validate subscription --no-strict origin/a/wis2/fake-centre-id/data/core
 
 # list children of a given WIS2 topic hierarchy level
 pywis-topics topic list wis2/a
 
 # validate a WIS2 topic hierarchy with wildcards (needs no-strict mode)
-pywis-topics topic validate origin/a/wis2/+/data/core --no-strict
+pywis-topics topic validate subscription origin/a/wis2/+/data/core --no-strict
+```
+
+### Validating topics for publication
+
+```bash
+# validate a WIS2 topic hierarchy
+pywis-topics topic validate publication origin/a/wis2/ca-eccc-msc  # fails
+pywis-topics topic validate publication origin/a/wis2/us-noaa-nws/data/core/weather/surface-based-observations/synop
+
+# validate a WIS2 topic hierarchy
+pywis-topics topic validate publication origin/a/wis2/ca-eccc-msc  # fails
+# validate a WIS2 topic hierarchy in no-strict mode
+pywis-topics topic validate publication --no-strict origin/a/wis2/fake-centre-id/data/core
 ```
 
 ### Centre identification validation

--- a/pywis_topics/bundle.py
+++ b/pywis_topics/bundle.py
@@ -78,7 +78,7 @@ def sync_bundle() -> None:
                 shutil.copyfileobj(src, dest)
 
     LOGGER.debug('Downloading IANA TLDs')
-    IANA_URL = 'https://data.iana.org/TLD/tlds-alpha-by-domain.txt'
+    IANA_URL = 'https://wmo-im.github.io/wis2-topic-hierarchy/iana-tlds/tlds-alpha-by-domain.txt'  # noqa
     iana_file = WIS2_TOPIC_HIERARCHY_DIR_TEMP / 'tlds-alpha-by-domain.txt'
     with iana_file.open('wb') as fh:
         fh.write(urlopen_(f'{IANA_URL}').read())

--- a/pywis_topics/pygeoapi_plugin.py
+++ b/pywis_topics/pygeoapi_plugin.py
@@ -138,6 +138,16 @@ PROCESS_VALIDATE_TOPIC = {
     'links': WIS2_TOPIC_HIERARCHY_LINKS,
     'inputs': {
         'topic': WIS2_TOPIC_HIERARCHY_INPUT_TOPIC,
+        'strict': {
+            'type': 'boolean',
+            'default': False,
+            'description': 'Validate in strict mode (default true)'
+        },
+        'publication': {
+            'type': 'boolean',
+            'default': False,
+            'description': 'Topic is publication-based (default false)'
+        }
     },
     'outputs': {
         'result': {
@@ -223,6 +233,8 @@ class WIS2TopicHierarchyValidateTopicProcessor(BaseProcessor):
         response = None
         mimetype = 'application/json'
         topic = data.get('topic')
+        publication = data.get('publication', False)
+        strict = data.get('strict', True)
 
         if topic is None:
             msg = 'Missing topic'
@@ -231,8 +243,11 @@ class WIS2TopicHierarchyValidateTopicProcessor(BaseProcessor):
 
         LOGGER.debug('Querying topic')
         th = TopicHierarchy()
+        topic_is_valid = th.validate(
+            topic, strict=strict, publication=publication)
+
         response = {
-            'topic_is_valid': th.validate(topic)
+            'topic_is_valid': topic_is_valid
         }
         return mimetype, response
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -75,10 +75,15 @@ class WIS2TopicHierarchyTest(unittest.TestCase):
         """return to pristine state"""
         pass
 
-    def test_validate(self):
+    def test_validate_subscription(self):
         value = None
         with self.assertRaises(ValueError):
             _ = self.th.validate(value)
+
+        valid_topics = [
+            'cache/a/wis2',
+            'cache/a/wis2/ca-eccc-msc/data/core',
+        ]
 
         invalid_topics = [
             'invalid.topic.hierarchy',
@@ -88,16 +93,11 @@ class WIS2TopicHierarchyTest(unittest.TestCase):
             'a/wis2'
         ]
 
-        valid_topics = [
-            'cache/a/wis2',
-            'cache/a/wis2/ca-eccc-msc/data/core',
-        ]
+        for valid_topic in valid_topics:
+            self.assertTrue(self.th.validate(valid_topic))
 
         for invalid_topic in invalid_topics:
             self.assertFalse(self.th.validate(invalid_topic))
-
-        for valid_topic in valid_topics:
-            self.assertTrue(self.th.validate(valid_topic))
 
         value = 'cache/a/wis2/fake-centre-id/data/core'
         self.assertTrue(self.th.validate(value, strict=False))
@@ -149,6 +149,71 @@ class WIS2TopicHierarchyTest(unittest.TestCase):
         value = 'cache/a/wis2/ca-eccc-msc/data/core/weather/surface-based-observations/#'  # noqa
         self.assertTrue(self.th.validate(value, strict=False))
         self.assertFalse(self.th.validate(value))
+
+    def test_validate_publication(self):
+        value = None
+        with self.assertRaises(ValueError):
+            _ = self.th.validate(value)
+
+        valid_topics = [
+            'origin/a/wis2/kz-kazhydromet/data/core/weather/surface-based-observations/synop',  # noqa
+            'origin/a/wis2/uk-metoffice/data/core/ocean/surface-based-observations/drifting-ocean-profilers',  # noqa
+            'origin/a/wis2/ca-eccc-msc/data/core/ocean/experimental'  # noqa
+        ]
+
+        invalid_topics = [
+            'invalid.topic.hierarchy',
+            'ORIGIN/A/wis2',
+            'origin/a/wis2/ca-é',
+            'invalid/topic/hierarchy',
+            'a/wis2',
+            'cache/a/wis2',
+            'origin/a/wis2/ca-eccc-msc/data/core',
+            'cache/a/wis2/ca-eccc-msc/data/core',
+            'cache/a/wis2/ca-eccc-msc/data/core/weather/surface-based-observations1'  # noqa
+        ]
+
+        for valid_topic in valid_topics:
+            self.assertTrue(self.th.validate(valid_topic, publication=True))
+
+        for invalid_topic in invalid_topics:
+            self.assertFalse(self.th.validate(invalid_topic, publication=True))
+
+        value = 'cache/a/wis2/fake-centre-id/data/core'
+        self.assertFalse(self.th.validate(value, strict=False,
+                         publication=True))
+
+        value = 'cache/a/+'
+        self.assertFalse(self.th.validate(value, strict=False,
+                         publication=True))
+
+        value = 'cache/a/#'
+        self.assertFalse(self.th.validate(value, strict=False,
+                         publication=True))
+
+        value = 'cache/a/wis2/+/data/core/#'
+        self.assertFalse(self.th.validate(value, strict=False,
+                         publication=True))
+
+        value = 'cache/a/wis2/+/data/core/weather/#'
+        self.assertFalse(self.th.validate(value, strict=False,
+                         publication=True))
+
+        value = 'cache/a/wis2/+/data/#/weather'
+        self.assertFalse(self.th.validate(value, publication=True))
+
+        value = 'cache/a/wis2/+/data/core/weather/surface-based-observations'
+        self.assertFalse(self.th.validate(value, strict=False,
+                         publication=True))
+
+        value = 'origin/a/wis2/ca-eccc-msc/data/core/ocean'
+        self.assertTrue(self.th.validate(value, publication=True))
+
+        value = 'cache/a/wis2/ca-eccc-msc/data/core/ocean'
+        self.assertTrue(self.th.validate(value, publication=True))
+
+        value = 'cache/a/wis2/io-wis2dev-11-test/data/core/ocean'
+        self.assertTrue(self.th.validate(value, publication=True))
 
     def test_list_children(self):
         value = None


### PR DESCRIPTION
This PR splits topic validation to be driven by subscription (i.e. wis2downloader) or publication (i.e. pywcmp), the latter of which bound to [WTH Requirement 1B](https://wmo-im.github.io/wis2-topic-hierarchy/standard/wis2-topic-hierarchy-STABLE.html#_1_2_publishing).

Example: `origin/a/wis2/us-noaa-nws/data/core` is fine for subscription, but not for data publication (note: pywcmp uses pywis-topics for topic validation for MQTT links in WCMP2 records (cc @golfvert)).

Note that the PR also caches IANA TLDs (now, from https://wmo-im.github.io/wis2-topic-hierarchy/iana-tlds/tlds-alpha-by-domain.txt) due to 403s from the IANA website.